### PR TITLE
fix(adapters): codex session naming skips startup probe and injected wrappers

### DIFF
--- a/cost_xray/adapters/anthropic.py
+++ b/cost_xray/adapters/anthropic.py
@@ -5,8 +5,8 @@ import re
 
 from cost_xray import detectors
 from cost_xray import events as ev
+from cost_xray.adapters import naming
 
-_NAME_MAX = 40
 _CWD_RE = re.compile(
     r"invoked in the following environment:.{0,200}?[Pp]rimary working directory:\s*(/[^\s\"',\\]+)",
     re.S)
@@ -23,16 +23,17 @@ def project_name(records):
     return None
 
 
-def _first_human_text(content):
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        for b in content:
-            if isinstance(b, dict) and b.get("type") == "text":
-                t = (b.get("text") or "").strip()
-                if t and not t.startswith("<"):
-                    return t
-    return None
+def _user_texts(msgs):
+    for m in msgs or []:
+        if not isinstance(m, dict) or m.get("role") != "user":
+            continue
+        content = m.get("content")
+        if isinstance(content, str):
+            yield content
+        elif isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "text":
+                    yield b.get("text") or ""
 
 
 def session_name(records):
@@ -42,17 +43,8 @@ def session_name(records):
         msgs = req.get("messages") if isinstance(req, dict) else None
         if msgs and (best is None or len(msgs) > len(best)):
             best = msgs
-    for m in best or []:
-        if m.get("role") != "user":
-            continue
-        t = _first_human_text(m.get("content"))
-        if not t:
-            continue
-        t = " ".join(t.split())
-        if t.lower() == "quota":
-            continue
-        return t[:_NAME_MAX] + ("…" if len(t) > _NAME_MAX else "")
-    return None
+    return naming.human_label(
+        t for t in _user_texts(best) if t.strip().lower() != "quota")
 
 
 THINKING_R = 0.39

--- a/cost_xray/adapters/naming.py
+++ b/cost_xray/adapters/naming.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+NAME_MAX = 40
+
+
+def human_label(texts):
+    for raw in texts:
+        t = " ".join((raw or "").split())
+        if t and not t.startswith("<"):
+            return t[:NAME_MAX] + ("…" if len(t) > NAME_MAX else "")
+    return None

--- a/cost_xray/adapters/openai.py
+++ b/cost_xray/adapters/openai.py
@@ -4,10 +4,10 @@ import json
 import re
 
 from cost_xray import events as ev
+from cost_xray.adapters import naming
 
 RESPONSES_PATH = "/backend-api/codex/responses"
 
-_NAME_MAX = 40
 _CWD_RE = re.compile(r"(?:working directory:|<cwd>)\s*(/[^\s\"'<,\\]+)", re.I)
 
 
@@ -19,7 +19,7 @@ def project_name(records):
     return None
 
 
-def session_name(records):
+def _user_texts(records):
     for rec in records:
         fr = _frame(rec) if isinstance(rec, dict) else None
         if not (isinstance(fr, dict) and fr.get("type") == "response.create"):
@@ -28,11 +28,11 @@ def session_name(records):
             if isinstance(item, dict) and item.get("role") == "user":
                 for b in item.get("content") or []:
                     if isinstance(b, dict) and b.get("type") in ("input_text", "text"):
-                        t = " ".join((b.get("text") or "").split())
-                        if t:
-                            return t[:_NAME_MAX] + ("…" if len(t) > _NAME_MAX else "")
-        return None
-    return None
+                        yield b.get("text") or ""
+
+
+def session_name(records):
+    return naming.human_label(_user_texts(records))
 
 
 THINKING_R = 1.0

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -72,6 +72,8 @@ applied to Codex's usage split. There is no cache-write premium on this wire.
 ## Quirks
 
 - Raw is frames, not turns — anything that assumes record-per-turn will mis-handle Codex.
+- The stream may open with an empty-input create (a startup probe), and the first real user item
+  arrives after injected developer / environment wrappers — session naming scans past both.
 - Builtins may lack a tool name; they fall back to their type as the leaf.
 - Reasoning items are empty on the wire (encrypted plaintext); rely on the reasoning-token count, not
   item text, for output thinking — see [../architecture.md](../architecture.md).

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -496,6 +496,20 @@ def test_session_name_is_first_human_user_message():
     assert adapters.session_name(codex, agent="codex") == "hello codex"
 
 
+def test_codex_session_name_skips_startup_probe_and_injected_wrappers():
+    from cost_xray import adapters
+    probe = {"frame": {"type": "response.create", "input": []}}
+    real = {"frame": {"type": "response.create", "input": [
+        {"type": "message", "role": "developer", "content": [
+            {"type": "input_text", "text": "<permissions instructions>sandboxing</permissions instructions>"}]},
+        {"type": "message", "role": "user", "content": [
+            {"type": "input_text", "text": "<environment_context>\n  <cwd>/home/u/proj</cwd>\n</environment_context>"}]},
+        {"type": "message", "role": "user", "content": [
+            {"type": "input_text", "text": "ok"}]}]}}
+    assert adapters.session_name([probe, real], agent="codex") == "ok"
+    assert adapters.session_name([probe], agent="codex") is None
+
+
 def test_project_name_anchored_to_env_block_not_conversation():
     from cost_xray import adapters
     env = ("# Environment\nYou have been invoked in the following environment: \n"


### PR DESCRIPTION
## Problem

Codex sessions showed no name in the TUI. `openai.session_name` returned unconditionally after inspecting the **first** `response.create` frame — but a real Codex stream can open with an empty-input create (a startup probe), so the name stayed `None` forever even though later frames carried the user message. Even past that frame, the first `role: user` item is an injected `<environment_context>` wrapper, not human text.

The adapter contract already specified the correct behavior ("the first user message, skipping startup probes and injected wrappers") — the code was out of spec.

## Fix

- `cost_xray/adapters/openai.py` — scan **all** `response.create` frames, yielding user text candidates.
- `cost_xray/adapters/naming.py` (new) — shared `human_label`: first non-`<`-wrapped human text, whitespace-collapsed, truncated to 40 chars. Both adapters previously duplicated this.
- `cost_xray/adapters/anthropic.py` — reuses the shared helper; the claude-specific "quota" probe filter stays in its adapter.
- `docs/providers/codex.md` — documents the verified wire fact (empty-input opening create, injected wrappers).

## Verification

- New test: probe frame + developer/env-wrapper/user items → name is the real user text; probe alone → `None`. Failed before the fix.
- `make ci` green (220 passed, 2 skipped).
- End-to-end: re-materialized all 18 real captured codex sessions — the previously unnamed session now names from its first user message; sessions still unnamed were verified to contain zero user text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)