### PR TITLE
docs: state Claude tokenization is calibrated estimation; announce opt-in exact mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ What is taking space in the context window right now — system prompt, every to
 
 Configured servers and tools that are injected into every request's prefix but never actually called. They pay their tool-schema overhead on every turn — cost-xray flags the dead weight.
 
-### Exact tokenization
+### Tokenization accuracy
 
-When you're logged into Claude Code (or have an API key), cost-xray sizes the hard-to-estimate parts — thinking and tool schemas — with Anthropic's own `count_tokens`, the only exact Claude tokenizer (no open-source one exists). Offline, it falls back to a calibrated estimate. Either way, totals reconcile to the provider's own `usage`.
+Claude's tokenizer is private — no official or open-source tokenizer exists — and calling Anthropic's `count_tokens` API for everything would add load and hit its limits. So for Claude, cost-xray uses an estimator plus proportional calibration: tiktoken sizes each part, the parts it mis-sizes most (thinking, tool schemas) get targeted corrections — pinned with `count_tokens` when you're logged in, a fixed ratio otherwise — and the rest is scaled so the calibrated total matches the provider's own `usage`. The total, and therefore the bill, is exact; only the split *between* sources in the same request is approximate. We benchmark those residuals continuously ([CONTRIBUTING.md](CONTRIBUTING.md)) and they're small enough for attribution work.
+
+**Coming soon:** an opt-in exact mode — every part sized by full `count_tokens` differencing — manually enabled, for users who need maximum per-source precision.
 
 ### Self-healing capture
 

--- a/docs/providers/claude-code.md
+++ b/docs/providers/claude-code.md
@@ -55,9 +55,14 @@ wire `usage`** — pin what tiktoken mis-sizes, proportion the rest:
 - **everything else** — tiktoken scaled so the calibrated total = wire usage − pins.
 
 Calibrated total = wire usage (**bill is exact**); the only approximation is the split between
-sibling events. Exact pins are gated on `count_tokens` auth (API key or the Claude Code OAuth login
-via `claude_login.py`) and **fail-open** — no auth ⇒ zero network calls, identical output, less
+sibling events — sizing every event via `count_tokens` would add per-event API load and rate-limit
+exposure, so the default calibrates instead and the residuals are benchmarked continuously. Exact
+pins are gated on `count_tokens` auth (API key or the Claude Code OAuth login via
+`claude_login.py`) and **fail-open** — no auth ⇒ zero network calls, identical output, less
 precise. Why pin, and the accuracy board: [../architecture.md](../architecture.md).
+
+**Planned:** an opt-in exact mode — every event sized by full `count_tokens` differencing —
+manually enabled for precision-critical use.
 
 ## Pricing
 


### PR DESCRIPTION
Repositions the tokenizer messaging to be explicit about the method and its bounds:

- **README** — `Exact tokenization` → `Tokenization accuracy`: Claude's tokenizer is private (no open-source equivalent) and sizing everything via `count_tokens` would add load and hit its limits, so the default is estimation + proportional calibration with targeted corrections (count_tokens pins when logged in, fixed-ratio thinking correction otherwise). Total/bill exact; per-source split approximate, with continuously benchmarked residuals.
- **docs/providers/claude-code.md** — same rationale in the Tokenizer section.
- Both announce the upcoming **opt-in exact mode**: every event sized by full `count_tokens` differencing, manually enabled for precision-critical users.

(The private design doc and TODO got the matching roadmap entry in the same change; `doc/` is gitignored so it doesn't appear in this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)